### PR TITLE
Add support for numeric and boolean values in PropTypes.oneOf

### DIFF
--- a/__testfixtures__/complex-props.input.js
+++ b/__testfixtures__/complex-props.input.js
@@ -17,6 +17,8 @@ MyComponent.propTypes = {
   optionalElement: PropTypes.element,
   optionalElementType: PropTypes.elementType,
   optionalEnum: PropTypes.oneOf(["News", "Photos"]),
+  optionalNumericEnum: PropTypes.oneOf([1, 2, 3]),
+  optionalMixedEnum: PropTypes.oneOf([1, "Unknown", false, () => {}]),
   optionalUnknownEnum: PropTypes.oneOf(Object.keys(arr)),
   optionalUnion: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   optionalArrayOf: PropTypes.arrayOf(PropTypes.number),

--- a/__testfixtures__/complex-props.output.js
+++ b/__testfixtures__/complex-props.output.js
@@ -12,6 +12,8 @@ interface MyComponentProps {
   optionalElement?: React.ReactElement;
   optionalElementType?: React.ElementType;
   optionalEnum?: "News" | "Photos";
+  optionalNumericEnum?: 1 | 2 | 3;
+  optionalMixedEnum?: 1 | "Unknown" | false | unknown;
   optionalUnknownEnum?: unknown[];
   optionalUnion?: string | number;
   optionalArrayOf?: number[];

--- a/transform.ts
+++ b/transform.ts
@@ -103,9 +103,21 @@ function getTSType(path: NodePath) {
       return arg.get("type").value !== "ArrayExpression"
         ? j.tsArrayType(j.tsUnknownKeyword())
         : j.tsUnionType(
-            arg
-              .get("elements")
-              .value.map(({ value }) => j.tsLiteralType(j.stringLiteral(value)))
+            arg.get("elements").value.map(({ type, value }) => {
+              switch (type) {
+                case "StringLiteral":
+                  return j.tsLiteralType(j.stringLiteral(value))
+
+                case "NumericLiteral":
+                  return j.tsLiteralType(j.numericLiteral(value))
+
+                case "BooleanLiteral":
+                  return j.tsLiteralType(j.booleanLiteral(value))
+
+                default:
+                  return j.tsUnknownKeyword()
+              }
+            })
           )
     }
 


### PR DESCRIPTION
Fixes #47, I think

I was curious, and am trying to learn more about codemods in any case, so I tried to figure out the issue that I opened an hour ago. This PR updates how we handle `PropTypes.oneOf` in cases where the arguments are not strings. Numeric and boolean literals are kept as-is, and anything else is converted to unknown.

Some notes:
- I've added a handful of tests (really slick testing setup, by the way; they're very simple to modify and yet totally realistic) and verified that they fail without this change
- I ran `npm run lint` and `npm run format` before pushing this
- To start off development, I just ran `npm i`; I don't see a package-lock.json in the repo and assume that's intentional
- I did end up with a bunch of local changes to yarn.lock that I'm not sure if you want committed or not

Please let me know if I've overlooked something, if you'd like to see this documented or tested differently, or even if you're not actually working on this project anymore and don't have the energy or ability to review this. Thank you for your time!