### PR TITLE
Added Intuita 1-Click Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Codemod to convert React PropTypes to TypeScript types.
 
 ## Usage
 
-Run the following command with a file glob that matches the files you want to
+Easily run Ratchet on your project using Intuita VS Code extension:
+
+<a href="http://tinyurl.com/intuita-ratchet" target="_blank">
+  
+![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/0f884038739b64e1b243945fd1010cb1b4807e7b/static/img/intuita-badge.svg)
+
+</a>
+
+Or run the following command with a file glob that matches the files you want to
 convert.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Codemod to convert React PropTypes to TypeScript types.
 
 Easily run Ratchet on your project using the [Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension):
 
-<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> ![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.png) </a>
+<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> <img src="https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.png" alt="Intuita Run Codemod" width="200"/> </a>
 
 > To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Codemod to convert React PropTypes to TypeScript types.
 
 Easily run Ratchet on your project using the [Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension):
 
-<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> ![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.svg) </a>
+<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> ![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.png) </a>
 
 > To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Codemod to convert React PropTypes to TypeScript types.
 
 ## Usage
 
-Easily run Ratchet on your project using the Intuita VS Code extension:
+Easily run Ratchet on your project using the [Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension):
 
 <a href="http://tinyurl.com/intuita-ratchet" target="_blank"> ![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.svg) </a>
 
-> To use the 1-click run feature, [install the Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension) first. <br> To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
+> To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
 
 Or run the following command with a file glob that matches the files you want to
 convert.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,18 @@ Codemod to convert React PropTypes to TypeScript types.
 
 ## Usage
 
-Easily run Ratchet on your project using the [Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension):
+Thanks to my friends at Intuita, you can easily run Ratchet on your project
+using the
+[Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension):
 
-<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> <img src="https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.png" alt="Intuita Run Codemod" width="200"/> </a>
+<a href="http://tinyurl.com/intuita-ratchet" target="_blank">
+<img src="https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.png" alt="Intuita Run Codemod" width="200"/>
+</a>
 
-> To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
+> To learn more about using the extension,
+> [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart).
+> If you encounter any issues, please
+> [reach out](https://www.intuita.io/community) to my good friends at Intuita.
 
 Or run the following command with a file glob that matches the files you want to
 convert.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ Codemod to convert React PropTypes to TypeScript types.
 
 ## Usage
 
-Easily run Ratchet on your project using Intuita VS Code extension:
+Easily run Ratchet on your project using the Intuita VS Code extension:
 
-<a href="http://tinyurl.com/intuita-ratchet" target="_blank">
-  
-![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/0f884038739b64e1b243945fd1010cb1b4807e7b/static/img/intuita-badge.svg)
+<a href="http://tinyurl.com/intuita-ratchet" target="_blank"> ![Open in Intuita](https://raw.githubusercontent.com/intuita-inc/intuita-docs/master/static/img/intuita-badge.svg) </a>
 
-</a>
+> To use the 1-click run feature, [install the Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension) first. <br> To learn more about using the extension, [read the docs here](https://docs.intuita.io/docs/vs-code-extension/quickstart). If you encounter any issues, please [let us know.](https://www.intuita.io/community)
 
 Or run the following command with a file glob that matches the files you want to
 convert.
@@ -36,7 +34,7 @@ npx jscodeshift -t https://mskelton.dev/ratchet.ts src/**/*.{js,jsx}
 
 ## Try it Online!
 
-In addition to the CLI, you can use Ratchet online at
+Additionally, you can use Ratchet online at
 [mskelton.dev/ratchet](https://mskelton.dev/ratchet)! Simply paste your input on
 the left and instantly see the output on the right!
 


### PR DESCRIPTION
Added support for running [Ratchet](https://github.com/mskelton/ratchet/) using the [Intuita VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension). Now you can 1-click run Ratchet using Intuita VSCE on your projects.

This addition allows you to use Intuita's features with Ratchet, such as:

- Integration with [Intuita's platform](https://www.intuita.io/).
- Dry-run Ratchet (and other codemods).
- Review and edit changes made by the codemod.
- Report issues with codemod accuracy, and get help from a [community of codemod experts](https://www.intuita.io/community).
- Target paths/files during codemod runs.

>💡 To learn more about the features you can use while running Ratchet with Intuita's VSCE, [read the docs here.](https://docs.intuita.io/docs/vs-code-extension/running-codemods)